### PR TITLE
SCRPT-14: zod deploy:create command throws "Error creating container: 409 Client Error: Conflict" when running Ansible playbook

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,38 +2,38 @@ image: timbru31/ruby-node
 
 stages:
   - Troubleshooting
-  # - Build
-  # - Test
-  # - Deploy
+  - Build
+  - Test
+  - Deploy
 
-# cache:
-#   paths:
-#     - zod/node_modules/
+cache:
+  paths:
+    - zod/node_modules/
 
-# Install Dependencies:
-#   stage: Build
-#   script:
-#     - cd zod
-#     - yarn install
+Install Dependencies:
+  stage: Build
+  script:
+    - cd zod
+    - yarn install
     
-# Build:
-#   stage: Build
-#   script:
-#     - cd zod
-#     - ./node_modules/typescript/bin/tsc
+Build:
+  stage: Build
+  script:
+    - cd zod
+    - ./node_modules/typescript/bin/tsc
 
-# Test:
-#   stage: Test
-#   script:
-#     - cd zod
-#     - mv .env.example .env
-#     - yarn test
+Test:
+  stage: Test
+  script:
+    - cd zod
+    - mv .env.example .env
+    - yarn test
 
 Upload tarbells:
   stage: Troubleshooting
-  # only:
-  #   variables:
-  #     - $CI_COMMIT_REF_NAME == "master"
+  only:
+    variables:
+      - $CI_COMMIT_REF_NAME == "master"
   script:
     - cd zod
     - yarn install

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,6 +36,7 @@ Upload tarbells:
   #     - $CI_COMMIT_REF_NAME == "master"
   script:
     - cd zod
+    - yarn install
     - apt-get update
     - apt-get install rename -y
     - yarn global add @oclif/dev-cli

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,38 +1,39 @@
 image: timbru31/ruby-node
 
 stages:
-  - Build
-  - Test
-  - Deploy
+  - Troubleshooting
+  # - Build
+  # - Test
+  # - Deploy
 
-cache:
-  paths:
-    - zod/node_modules/
+# cache:
+#   paths:
+#     - zod/node_modules/
 
-Install Dependencies:
-  stage: Build
-  script:
-    - cd zod
-    - yarn install
+# Install Dependencies:
+#   stage: Build
+#   script:
+#     - cd zod
+#     - yarn install
     
-Build:
-  stage: Build
-  script:
-    - cd zod
-    - ./node_modules/typescript/bin/tsc
+# Build:
+#   stage: Build
+#   script:
+#     - cd zod
+#     - ./node_modules/typescript/bin/tsc
 
-Test:
-  stage: Test
-  script:
-    - cd zod
-    - mv .env.example .env
-    - yarn test
+# Test:
+#   stage: Test
+#   script:
+#     - cd zod
+#     - mv .env.example .env
+#     - yarn test
 
 Upload tarbells:
-  stage: Deploy
-  only:
-    variables:
-      - $CI_COMMIT_REF_NAME == "master"
+  stage: Troubleshooting
+  # only:
+  #   variables:
+  #     - $CI_COMMIT_REF_NAME == "master"
   script:
     - cd zod
     - apt-get update

--- a/zod/.vscode/launch.json
+++ b/zod/.vscode/launch.json
@@ -58,7 +58,7 @@
             "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
             "args": [
                 "--grep",
-                "calls _playbook.command when calling destroySpaContainers"
+                "fails when FAILED is present in ansible command output and does not contain any recoverable errors"
             ],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"

--- a/zod/.vscode/launch.json
+++ b/zod/.vscode/launch.json
@@ -22,7 +22,7 @@
             "program": "${workspaceFolder}/bin/run",
             "args": [
                 "deploy:create",
-                "v0.0.42"
+                "v0.0.54"
             ],
             "cwd": "${workspaceRoot}",
             "console": "integratedTerminal"

--- a/zod/node-ansible/Dockerfile
+++ b/zod/node-ansible/Dockerfile
@@ -2,6 +2,6 @@ FROM nikolaik/python-nodejs:python3.8-nodejs12
 
 RUN apt-get update && apt-get install -y ansible
 
-RUN pip install docker-py
+RUN pip install docker
 
 CMD ["/bin/sh"]

--- a/zod/node-ansible/zod.sh
+++ b/zod/node-ansible/zod.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # docker run -it -v "$(PWD)/../:/zod" node-ansible /zod/node-ansible/zod.sh
-zod/bin/run deploy:clean staging
+zod/bin/run deploy:create v0.0.52

--- a/zod/node-ansible/zod.sh
+++ b/zod/node-ansible/zod.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # docker run -it -v "$(PWD)/../:/zod" node-ansible /zod/node-ansible/zod.sh
-zod/bin/run deploy:create v0.0.52
+zod/bin/run deploy:create v0.0.54

--- a/zod/src/adapters/cdn/spaces.ts
+++ b/zod/src/adapters/cdn/spaces.ts
@@ -1,10 +1,10 @@
 import 'reflect-metadata'
-import {Cdn} from '../../interfaces/cdn'
-import {autoInjectable, inject} from 'tsyringe'
-import {S3} from 'aws-sdk'
-import {deleteRecursive} from 's3-commons'
-import {Config, Environment} from '../../interfaces/config'
-import {success, warn} from '../../core/color'
+import { Cdn } from '../../interfaces/cdn'
+import { autoInjectable, inject } from 'tsyringe'
+import { S3 } from 'aws-sdk'
+import { deleteRecursive } from 's3-commons'
+import { Config, Environment } from '../../interfaces/config'
+import { success, warn } from '../../core/color'
 
 export const CDN_ERRORS = {
   DELETING_MORE_THAN_IS_AVAILABLE: (keep: number, totalDeployments: number) => (`You want to keep ${keep} deployments. There are ${totalDeployments} deployments remaining. Zod will not send any deployments to the phantom zone.`),
@@ -58,16 +58,16 @@ export default class implements Cdn {
 
     const currentDeploymentsOnEnvironment =
       allObjectsUnderReleasePath
-      .reduce((acc: Map<string, Date>, object) => {
-        if (!object.Key || !object.LastModified)
+        .reduce((acc: Map<string, Date>, object) => {
+          if (!object.Key || !object.LastModified)
+            return acc
+
+          const deploymentTag = this._deploymentTag(object.Key)
+          if (deploymentTag)
+            return acc.set(deploymentTag, object.LastModified)
+
           return acc
-
-        const deploymentTag = this._deploymentTag(object.Key)
-        if (deploymentTag)
-          return acc.set(deploymentTag, object.LastModified)
-
-        return acc
-      }, new Map())
+        }, new Map())
 
     const totalDeployments = currentDeploymentsOnEnvironment.size
 
@@ -80,32 +80,35 @@ export default class implements Cdn {
 
     const deploymentsToDelete =
       [...sortedDeployments.entries()]
-      .slice(0, sortedDeployments.size - keep)
-      .map(deployment => `${releasePath}${deployment[0]}`)
+        .slice(0, sortedDeployments.size - keep)
+        .map(deployment => `${releasePath}${deployment[0]}`)
 
     const deleteObjectsDescriptor =
       deploymentsToDelete
-      .map(deployment => deployment)
-      .join(', ')
+        .map(deployment => deployment)
+        .join(', ')
 
     console.log(warn(CDN_MESSAGES.ATTEMPTING_TO_DESTROY_CDN_ASSETS(deleteObjectsDescriptor)))
 
     const deletedCount = await deploymentsToDelete
-    .reduce(async (acc, deploymentPath) => {
-      const accumulator = await acc
-      const totalDeletedForReleasePath = await deleteRecursive(
-        this._s3,
-        this._bucketName,
-        deploymentPath,
-      )
-      return Promise.resolve(accumulator + totalDeletedForReleasePath)
-    }, Promise.resolve(0))
+      .reduce(async (acc, deploymentPath) => {
+        const accumulator = await acc
+        const totalDeletedForReleasePath = await deleteRecursive(
+          this._s3,
+          this._bucketName,
+          deploymentPath,
+        )
+        return Promise.resolve(accumulator + totalDeletedForReleasePath)
+      }, Promise.resolve(0))
 
     if (!deletedCount)
       return Promise.reject([false, CDN_ERRORS.ERROR_DELETING_DEPLOYMENTS])
 
     console.log(success(CDN_MESSAGES.SUCCESSFULLY_DELETED_THESE_DEPLOYMENTS(deleteObjectsDescriptor)))
 
-    return Promise.resolve([true, deploymentsToDelete])
+    return Promise.resolve([
+      true,
+      deploymentsToDelete.map(deployment => deployment.split('/')[deployment.split('/').length - 1]),
+    ])
   }
 }

--- a/zod/src/adapters/docker/ansible.ts
+++ b/zod/src/adapters/docker/ansible.ts
@@ -1,11 +1,11 @@
-import {Docker} from '../../interfaces/docker'
-import {AnsiblePlaybook, Options} from 'ansible-playbook-cli-js'
+import { Docker } from '../../interfaces/docker'
+import { AnsiblePlaybook, Options } from 'ansible-playbook-cli-js'
 import path from 'path'
 import fs from 'fs'
-import {inject, autoInjectable} from 'tsyringe'
-import {Config} from '../../interfaces/config'
-import {success, warn} from '../../core/color'
-import {ENV_VARIABLE_NOT_FOUND} from '../config'
+import { inject, autoInjectable } from 'tsyringe'
+import { Config } from '../../interfaces/config'
+import { success, warn } from '../../core/color'
+import { ENV_VARIABLE_NOT_FOUND } from '../config'
 
 export const ANSIBLE_MESSAGES = {
   STAGING_URL_CREATED: (stagingUrl: string) => `A staging container has been deployed at ${stagingUrl}`,

--- a/zod/src/adapters/docker/ansible.ts
+++ b/zod/src/adapters/docker/ansible.ts
@@ -1,11 +1,11 @@
-import { Docker } from '../../interfaces/docker'
-import { AnsiblePlaybook, Options } from 'ansible-playbook-cli-js'
+import {Docker} from '../../interfaces/docker'
+import {AnsiblePlaybook, Options} from 'ansible-playbook-cli-js'
 import path from 'path'
 import fs from 'fs'
-import { inject, autoInjectable } from 'tsyringe'
-import { Config } from '../../interfaces/config'
-import { success, warn } from '../../core/color'
-import { ENV_VARIABLE_NOT_FOUND } from '../config'
+import {inject, autoInjectable} from 'tsyringe'
+import {Config} from '../../interfaces/config'
+import {success, warn} from '../../core/color'
+import {ENV_VARIABLE_NOT_FOUND} from '../config'
 
 export const ANSIBLE_MESSAGES = {
   STAGING_URL_CREATED: (stagingUrl: string) => `A staging container has been deployed at ${stagingUrl}`,
@@ -23,6 +23,14 @@ export const inventoryPath = path.resolve(path.join(ansiblePath, '/xura'))
 export const privateKeyPath = path.resolve(path.join(ansiblePath, '/droplet4'))
 
 export const ansiblePlaybookFailureIndicator = 'FAILED!'
+
+export const ansiblePlaybookRecoverableErrors = [
+  // within the gitlab-ci/gitlab_runner, createSpaContainers will throw this error
+  // upon running the ansible-playbook command for spinning up a SPA container, the given play will fail with this error
+  // the container will still spin up and there are no detectable failures other than the playbook response
+  // therfore, this is becoming a "recoverable" error
+  'Error creating container: 409 Client Error: Conflict',
+]
 
 export enum ANSIBLE_COMMANDS {
   CREATE_SPA = 'create-spa',
@@ -75,8 +83,10 @@ export default class implements Docker {
     if (!playbookResponse[0])
       return Promise.reject(playbookResponse[1])
 
+    const playbookCommandSucceeded = (!(playbookResponse[1]?.raw.includes(ansiblePlaybookFailureIndicator)) || ansiblePlaybookRecoverableErrors.some(error => playbookResponse[1]?.raw.includes(error)))
+
     console.log(playbookResponse[1])
-    return Promise.resolve([!(playbookResponse[1]?.raw.includes(ansiblePlaybookFailureIndicator) || false), playbookResponse[1]?.raw])
+    return Promise.resolve([playbookCommandSucceeded, playbookResponse[1]?.raw])
   }
 
   private _runAnsibleCommand: (command: string) => Promise<[boolean, Record<string, any>]> =

--- a/zod/src/core/ansible/roles/spa/tasks/create.yml
+++ b/zod/src/core/ansible/roles/spa/tasks/create.yml
@@ -13,6 +13,7 @@
     name: "{{containerName}}"
     image: httpd:alpine
     state: started
+    recreate: yes
     restart_policy: always
     env:
       LETSENCRYPT_HOST: "{{containerName}}"

--- a/zod/src/core/ansible/roles/spa/tasks/create.yml
+++ b/zod/src/core/ansible/roles/spa/tasks/create.yml
@@ -16,10 +16,8 @@
 
 - name: Spin up SPA Container
   docker_container:
+    name: "{{containerName}}"
     image: httpd:alpine
-    state: started
-    recreate: yes
-    restart_policy: always
     env:
       LETSENCRYPT_HOST: "{{containerName}}"
       LETSENCRYPT_EMAIL: joe307bad@gmail.com

--- a/zod/src/core/ansible/roles/spa/tasks/create.yml
+++ b/zod/src/core/ansible/roles/spa/tasks/create.yml
@@ -8,6 +8,12 @@
     url: "{{indexHtmlCdnUrl}}"
     dest: "{{stagingHtdocs}}"
 
+- name: Remove SPA Container if exists
+  docker_container:
+    name: "{{containerName}}"
+    state: absent
+    force_kill: yes
+
 - name: Spin up SPA Container
   docker_container:
     name: "{{containerName}}"

--- a/zod/src/core/ansible/roles/spa/tasks/create.yml
+++ b/zod/src/core/ansible/roles/spa/tasks/create.yml
@@ -16,7 +16,6 @@
 
 - name: Spin up SPA Container
   docker_container:
-    name: "{{containerName}}"
     image: httpd:alpine
     state: started
     recreate: yes


### PR DESCRIPTION
This PR provides an array of recoverable errors for GitLab CI (or consumers of `zod deploy:create`) that will prevent the program from failing. Specifically, this PR allows the program to ignore when the following error occurs: `Error creating container: 409 Client Error: Conflict`. This error is thrown whenever the Ansible playbook is executed to spin up a SPA container. The container is still created, so there is currently no discernible drawback from this error being thrown. Therefore, we are going to ignore it for now.