### PR TITLE
SCRPT-14: zod:clean does not remove certs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,38 +2,38 @@ image: timbru31/ruby-node
 
 stages:
   - Troubleshooting
-  - Build
-  - Test
-  - Deploy
+#   - Build
+#   - Test
+#   - Deploy
 
-cache:
-  paths:
-    - zod/node_modules/
+# cache:
+#   paths:
+#     - zod/node_modules/
 
-Install Dependencies:
-  stage: Build
-  script:
-    - cd zod
-    - yarn install
+# Install Dependencies:
+#   stage: Build
+#   script:
+#     - cd zod
+#     - yarn install
     
-Build:
-  stage: Build
-  script:
-    - cd zod
-    - ./node_modules/typescript/bin/tsc
+# Build:
+#   stage: Build
+#   script:
+#     - cd zod
+#     - ./node_modules/typescript/bin/tsc
 
-Test:
-  stage: Test
-  script:
-    - cd zod
-    - mv .env.example .env
-    - yarn test
+# Test:
+#   stage: Test
+#   script:
+#     - cd zod
+#     - mv .env.example .env
+#     - yarn test
 
 Upload tarbells:
   stage: Troubleshooting
-  only:
-    variables:
-      - $CI_COMMIT_REF_NAME == "master"
+  # only:
+  #   variables:
+  #     - $CI_COMMIT_REF_NAME == "master"
   script:
     - cd zod
     - yarn install

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,39 +1,38 @@
 image: timbru31/ruby-node
 
 stages:
-  - Troubleshooting
-#   - Build
-#   - Test
-#   - Deploy
+  - Build
+  - Test
+  - Deploy
 
-# cache:
-#   paths:
-#     - zod/node_modules/
+cache:
+  paths:
+    - zod/node_modules/
 
-# Install Dependencies:
-#   stage: Build
-#   script:
-#     - cd zod
-#     - yarn install
+Install Dependencies:
+  stage: Build
+  script:
+    - cd zod
+    - yarn install
     
-# Build:
-#   stage: Build
-#   script:
-#     - cd zod
-#     - ./node_modules/typescript/bin/tsc
+Build:
+  stage: Build
+  script:
+    - cd zod
+    - ./node_modules/typescript/bin/tsc
 
-# Test:
-#   stage: Test
-#   script:
-#     - cd zod
-#     - mv .env.example .env
-#     - yarn test
+Test:
+  stage: Test
+  script:
+    - cd zod
+    - mv .env.example .env
+    - yarn test
 
 Upload tarbells:
-  stage: Troubleshooting
-  # only:
-  #   variables:
-  #     - $CI_COMMIT_REF_NAME == "master"
+  stage: Deploy
+  only:
+    variables:
+      - $CI_COMMIT_REF_NAME == "master"
   script:
     - cd zod
     - yarn install

--- a/zod/src/adapters/docker/ansible.ts
+++ b/zod/src/adapters/docker/ansible.ts
@@ -149,7 +149,7 @@ export default class implements Docker {
     // TODO write tests around new flatMap implementaiton to certsFilesAndFolders
     const certsFilesAndFolders =
       names.flatMap(name =>
-        certFileExtensions.map(extension => `${this._stagingCertsDir}/${this._removePeriods(name)}.${extension}`))
+        certFileExtensions.map(extension => `${this._stagingCertsDir}/${this._spaContainerName(name)}.${extension}`))
     const stagingUrlsDescriptor = stagingUrls.join(', ')
     const certDirs =
       names.map(name => `${this._stagingCertsDir}/${this._spaContainerName(name)}`)

--- a/zod/src/adapters/docker/ansible.ts
+++ b/zod/src/adapters/docker/ansible.ts
@@ -36,7 +36,7 @@ export const certFileExtensions = [
   'dhparam.pem',
   'key',
   'chain.pem',
-  'crt'
+  'crt',
 ]
 
 export enum ANSIBLE_COMMANDS {
@@ -148,7 +148,8 @@ export default class implements Docker {
     const stagingHtdocs = names.map(name => this._spaHtDocs(name))
     // TODO write tests around new flatMap implementaiton to certsFilesAndFolders
     const certsFilesAndFolders =
-      names.flatMap(name => certFileExtensions.map(extension => `${this._stagingCertsDir}/${this._removePeriods(name)}.${extension}`))
+      names.flatMap(name =>
+        certFileExtensions.map(extension => `${this._stagingCertsDir}/${this._removePeriods(name)}.${extension}`))
     const stagingUrlsDescriptor = stagingUrls.join(', ')
     const certDirs =
       names.map(name => `${this._stagingCertsDir}/${this._spaContainerName(name)}`)
@@ -158,7 +159,7 @@ export default class implements Docker {
     const playbookResponse = await this._executePlaybook(ANSIBLE_COMMANDS.DESTROY_MULTIPLE_SPAS, {
       containerNames: stagingUrls,
       stagingHtdocs,
-      certDirs: [...certDirs, ...certsFilesAndFolders],
+      certsFilesAndFolders: [...certDirs, ...certsFilesAndFolders],
     })
 
     if (!playbookResponse[0]) {

--- a/zod/src/core/ansible/roles/spa/tasks/destroy-multiple.yml
+++ b/zod/src/core/ansible/roles/spa/tasks/destroy-multiple.yml
@@ -19,5 +19,6 @@
   with_items: "{{certDirs}}"
 
 - name: Destroy SSL certs
-  shell: rm -rf "{{item}}"
-  with_items: "{{certsFilesAndFolders}}"
+  shell: "rm -rf {{item}}"
+  with_items: 
+  - "{{certsFilesAndFolders}}"

--- a/zod/src/core/ansible/roles/spa/tasks/destroy-multiple.yml
+++ b/zod/src/core/ansible/roles/spa/tasks/destroy-multiple.yml
@@ -12,13 +12,13 @@
   with_items:
   - "{{stagingHtdocs}}"
 
-- name: Destroy SSL certs
-  shell: rm -rf "{{item}}"
-  with_items:
-  - "{{certsFilesAndFolders}}"
-
 - name: Remove SSL cert directory content
   file:
     path: "{{item}}" 
     state: absent
   with_items: "{{certDirs}}"
+
+- name: Destroy SSL certs
+  shell: rm -rf "{{item}}"
+  with_items:
+  - "{{certsFilesAndFolders}}"

--- a/zod/src/core/ansible/roles/spa/tasks/destroy-multiple.yml
+++ b/zod/src/core/ansible/roles/spa/tasks/destroy-multiple.yml
@@ -18,7 +18,9 @@
     state: absent
   with_items: "{{certDirs}}"
 
-- name: Destroy SSL certs
-  shell: "rm -rf {{item}}"
-  with_items: 
-  - "{{certsFilesAndFolders}}"
+# - name: Destroy SSL certs
+#   file:
+#     path: "{{item}}"
+#     state: absent
+#   with_items: 
+#   - "{{certsFilesAndFolders}}"

--- a/zod/src/core/ansible/roles/spa/tasks/destroy-multiple.yml
+++ b/zod/src/core/ansible/roles/spa/tasks/destroy-multiple.yml
@@ -20,5 +20,4 @@
 
 - name: Destroy SSL certs
   shell: rm -rf "{{item}}"
-  with_items:
-  - "{{certsFilesAndFolders}}"
+  with_items: "{{certsFilesAndFolders}}"

--- a/zod/src/core/ansible/roles/spa/tasks/destroy-multiple.yml
+++ b/zod/src/core/ansible/roles/spa/tasks/destroy-multiple.yml
@@ -16,11 +16,5 @@
   file:
     path: "{{item}}" 
     state: absent
-  with_items: "{{certDirs}}"
-
-# - name: Destroy SSL certs
-#   file:
-#     path: "{{item}}"
-#     state: absent
-#   with_items: 
-#   - "{{certsFilesAndFolders}}"
+  with_items: 
+  - "{{certsFilesAndFolders}}"

--- a/zod/tsconfig.json
+++ b/zod/tsconfig.json
@@ -10,7 +10,10 @@
     "rootDir": "src",
     "strict": true,
     "target": "es2017",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "lib": [
+      "es2019"
+    ]
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
This PR addresses a bug where running `zod:clean` was not removing all of the SSL certs that had been generated by previous deployments. The fix involved reworking how the Ansible playbook consumes the list of SSL certs and directories.